### PR TITLE
chore: lower auto-compact threshold to 40%

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE": "40"
+  }
+}


### PR DESCRIPTION
Adds .claude/settings.json with CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=40 so Claude Code auto-compacts at 40% of context instead of ~85-95% default. User-authorized rollout 2026-05-15.